### PR TITLE
Creating requirements.txt for docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+# docs
+sphinx==2.4.1


### PR DESCRIPTION
Sphinx compiles docs using version 1.8.5 as shown below:
```
**Running Sphinx v1.8.5**
loading translations [en]... done
making output directory...
loading intersphinx inventory from https://docs.python.org/3/objects.inv...
loading intersphinx inventory from https://requests.readthedocs.io/en/master/objects.inv...
building [mo]: targets for 0 po files that are out of date
building [readthedocs]: targets for 2 source files that are out of date
updating environment: 2 added, 0 changed, 0 removed
reading sources... [ 50%] index
```

This PR forces Sphinx to use a newer version of Sphinx to compile the docs.