### PR TITLE
Email notifications for broken builds on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,16 @@ if: branch = master OR type != push
 os: linux
 dist: xenial
 
+notifications:
+  email:
+    if: branch = master AND type != pull_request
+    on_failure: always
+    recipients:
+      michael.haas01@sap.com
+      karthik.muthuswamy@sap.com
+      francesco.alda@sap.com
+      evgeny.arnautov@sap.com
+
 stages:
 - name: linting
 - name: test


### PR DESCRIPTION
Merge #18 first.

Given that we run system tests only on master, we should be sure to act on any problems. It is not as obvious as a failing PR. This commit adds email notifications for failed builds on master.