### PR TITLE
Add introduction to TOC

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,7 +1,7 @@
 .. _index:
 
-Welcome to Data Attribute Recommendation Python SDK documentation!
-==================================================================
+Data Attribute Recommendation Python SDK documentation
+======================================================
 
 The SDK
 *******
@@ -571,6 +571,7 @@ Table of Contents
     :maxdepth: 2
     :caption: Contents:
 
+    Introduction <self>
     api.rst
     retry.rst
     security.rst

--- a/docs/source/release_process.rst
+++ b/docs/source/release_process.rst
@@ -5,7 +5,7 @@ Creating a new release of the Data Attribute Recommendation SDK
 ===============================================================
 
 *This document describes how to publish a new release of the SDK
-to `pypi.org`_ and does not apply to simple use of the SDK.*
+to Pypi and does not apply to simple use of the SDK.*
 
 To create a new release of the Data Attribute Recommendation Python SDK and
 publish it to `pypi.org`_, you will need to have *write* access to the


### PR DESCRIPTION
The main page was missing from the "Contents" sidebar.