### PR TITLE
TOX: Remove pytest and bandit from envlist

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # exclude "system_tests" by default: these need service credentials
-envlist = py35, py36, py37, py38, flake8, bandit
+envlist = py35, py36, py37, py38
 
 [testenv]
 whitelist_externals = mkdir


### PR DESCRIPTION
These environments no longer exist.