### PR TITLE
Feat/traceability 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,12 +33,12 @@ notifications:
 
 
 stages:
-- name: linting
-- name: test
+# - name: linting
+# - name: test
 - name: "system tests"
-  if:  type != pull_request AND (branch = master OR tag =~ ^rel/.*$)
-- name: deploy
-  if: type != pull_request AND tag =~ ^rel/.*$
+#  if:  type != pull_request AND (branch = master OR tag =~ ^rel/.*$)
+# - name: deploy
+#  if: type != pull_request AND tag =~ ^rel/.*$
 
 language: python
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,12 +33,12 @@ notifications:
 
 
 stages:
-# - name: linting
-# - name: test
+- name: linting
+- name: test
 - name: "system tests"
-#  if:  type != pull_request AND (branch = master OR tag =~ ^rel/.*$)
-# - name: deploy
-#  if: type != pull_request AND tag =~ ^rel/.*$
+  if:  type != pull_request AND (branch = master OR tag =~ ^rel/.*$)
+- name: deploy
+  if: type != pull_request AND tag =~ ^rel/.*$
 
 language: python
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,12 +102,21 @@ jobs:
     install: skip
     script: skip
     deploy:
-      provider: pypi
-      username: __token__
-      distributions: "sdist bdist_wheel"
-      password:
-        secure: "Yo1GgXnDX8br7Gwy7IbIbTowfbuATV8hwMoWeQEfXb/rkPxJuElbGDb6xEy19E3qojxMbeY2Lm5ahyRXBcQmekyzG4/xa4aLqxa08TEYbH/QQi3T7pFaIpBdPwHE3e3dsKZIFJwFwPymjIBZGC79CQkkD2g2+9GvSSJVkc5OMY/q1rVeWeKxbNmLiSu9kIIusBt1nkmrctLaNNN6fRvjII61bxkujpmBjWGZcNmcVHqxXqEVplfAOhBymalrhl6ABtlzKxLoBWJchqILLsVGoIhHIcUFkA7PyH90UfR5k2mWh7W5kh44vbY4F/OV2Dr875RNc/BYfnNe/RofxtIg1B9Z5JLVpGXsUhfWBqDcymym+ugTdYwEL2D4S2cWEK5sSur+cb/Ib/CAwYUaVf6eWJERzsPKs+5bfHHpkphDUIs7Rp6Mf5bkPgiUgbyWQ0Wdx5a7WXqwHCVpskCDreCF54X4FQuHeSxXrOVQ1GnknpTm5ZCJhuB5ged1a6BmhzF4LbhalHZjmYqy37j+jCLAa8QrpoUkhvPrSKyUQVHnj8P8yw2jydHDdyuWoibwL+rbrHHeX66QreV/utBODfbx2j3tMzkAU8QqKsmP9hWnHFx5Lz6Dl/m8MniKbs7B3vMG3MCJsPz2nawHC/wlDeRqTTARZ+Fpc7VHzj2/ra8Egos="
-      on:
-        # Limitation on branches is done in the "stages" section, so if
-        # the stage is executed, we always want to deploy
-        all_branches: true
+      - provider: pypi
+        username: __token__
+        distributions: "sdist bdist_wheel"
+        password:
+          secure: "Yo1GgXnDX8br7Gwy7IbIbTowfbuATV8hwMoWeQEfXb/rkPxJuElbGDb6xEy19E3qojxMbeY2Lm5ahyRXBcQmekyzG4/xa4aLqxa08TEYbH/QQi3T7pFaIpBdPwHE3e3dsKZIFJwFwPymjIBZGC79CQkkD2g2+9GvSSJVkc5OMY/q1rVeWeKxbNmLiSu9kIIusBt1nkmrctLaNNN6fRvjII61bxkujpmBjWGZcNmcVHqxXqEVplfAOhBymalrhl6ABtlzKxLoBWJchqILLsVGoIhHIcUFkA7PyH90UfR5k2mWh7W5kh44vbY4F/OV2Dr875RNc/BYfnNe/RofxtIg1B9Z5JLVpGXsUhfWBqDcymym+ugTdYwEL2D4S2cWEK5sSur+cb/Ib/CAwYUaVf6eWJERzsPKs+5bfHHpkphDUIs7Rp6Mf5bkPgiUgbyWQ0Wdx5a7WXqwHCVpskCDreCF54X4FQuHeSxXrOVQ1GnknpTm5ZCJhuB5ged1a6BmhzF4LbhalHZjmYqy37j+jCLAa8QrpoUkhvPrSKyUQVHnj8P8yw2jydHDdyuWoibwL+rbrHHeX66QreV/utBODfbx2j3tMzkAU8QqKsmP9hWnHFx5Lz6Dl/m8MniKbs7B3vMG3MCJsPz2nawHC/wlDeRqTTARZ+Fpc7VHzj2/ra8Egos="
+        on:
+          # Limitation on branches is done in the "stages" section, so if
+          # the stage is executed, we always want to deploy
+          all_branches: true
+      - provider: releases
+        api_key:
+          secure: "m0kXSf53vJY95nb7lrM4N4KTiSmNuSoHfS3swxhjuoEdCPuaYHkpkHjPYH6ZNIjBbFEMGw4YENEcUdyzlshPe/WIX5IQ1LjFTZ1U9wP8Iup0VNW9NAHn32Q9oRUFKdD5IeCtjvQwGdVZbAoJM7+IwX19qqhgkPf1VEPPcq3zW+J/aZNg1ayfH+79x60vybapeG7a8QNvxNATrHaO07+xuWIoDaSKZA0ggDn2zxdaDGk/1SJRZsu67YA0DqFAYB8CtspgewJg7MIrLQcHps9yq+vp1sPHiWy9SH87CDyG9+NMXBb2rnvsmRwxXI659wFOQqMWmCgSs/L3IMPBCGziSqgw7MG5hLVpyrmExINuag2yricm0RDPYVxnJKBz3a7J4pl1zudpdfudich8WDinJk7TJHR3tTgIFx1ASmA20RiY22NUvHWpRL88jNJn5LXDyOaT5bT7c6i9VwxpUq234DXLQ9iUMrbs5P576x/Px71dfJ8RLv52D4TmwQYVzgRdFeFI/TOvyvIKA4dYfGylpsueIScZTn5G0p9srzqpRT8gr1sOlIsBHjISppeyEG6C3uTuhaP/zu7o+soQtiMHWm7G2/5BpUBz7JwMODMnK1f4B4stQJYo7Kx+KsGPUrkJVst07klya44EYGS7Ik8Dm6YsNhvc0safYxxNK71cqGY="
+        file: "system_test_results/traceability.html"
+        skip_cleanup: true
+        on:
+          # Limitation on branches is done in the "stages" section, so if
+          # the stage is executed, we always want to deploy
+          all_branches: true

--- a/system_tests/client/test_data_manager_client.py
+++ b/system_tests/client/test_data_manager_client.py
@@ -1,8 +1,11 @@
 from io import BytesIO
 
+import pytest
+
 from sap.aibus.dar.client.data_manager_client import DataManagerClient
 
 
+@pytest.mark.requirements(issues=["42"])
 class TestDataManagerClient:
     new_schema = {
         "features": [
@@ -66,6 +69,7 @@ class TestDataManagerClient:
 
         assert after_deletion_count == new_count - 1
 
+    @pytest.mark.requirements(issues=["42"])
     def test_dataset_upload(self, data_manager_client: DataManagerClient):
         csv = """
 manufacturer,description,category,subcategory

--- a/system_tests/client/test_model_manager_client.py
+++ b/system_tests/client/test_model_manager_client.py
@@ -1,6 +1,9 @@
+import pytest
+
 from sap.aibus.dar.client.model_manager_client import ModelManagerClient
 
 
+@pytest.mark.requirements(issues=["42"])
 class TestModelManagerClient:
     def test_model_templates(self, model_manager_client: ModelManagerClient):
         expected_model_template_id = "d7810207-ca31-4d4d-9b5a-841a644fd81f"

--- a/system_tests/conftest.py
+++ b/system_tests/conftest.py
@@ -87,14 +87,9 @@ def pytest_configure(config):
 
 def pytest_runtest_setup(item: Item):
     collected_issue_ids = []  # type: List[str]
-    print("pytest_runtest_setup")
-    print(item)
     for requirement_marker in item.iter_markers("requirements"):
-        print("MARKER")
-        print(requirement_marker)
         if requirement_marker and "issues" in requirement_marker.kwargs:
             collected_issue_ids.extend(requirement_marker.kwargs.get("issues"))
-        print("GOT ISSUES")
     # Only keep unique IDs and sorted them
     item.issue_ids = sorted(set(collected_issue_ids))
 

--- a/system_tests/conftest.py
+++ b/system_tests/conftest.py
@@ -1,5 +1,8 @@
 import os
+from typing import List
 
+from _pytest.nodes import Item
+from py.xml import html
 import pytest
 
 from sap.aibus.dar.client.data_manager_client import DataManagerClient
@@ -60,3 +63,80 @@ def inference_client(dar_url, credentials_source):
 def model_creator(dar_url, credentials_source):
     create_model = ModelCreator(dar_url, credentials_source)
     return create_model
+
+
+# Traceability report generation
+# The following hooks implement the traceability report generation.
+# This roughly works as follows:
+#
+# * In the runtest_setup hook, the issue ID is extracted from the closest
+#   `requirement` marker and stored on the test `item` object
+# * In the runtest_makereport hook, the issue ID is copied from the test `item`
+#   to the report object (basically, to the test result)
+# * Finally, the issue ID is consumed in the pytest_html_results_table_header and
+#   pytest_html_results_table_row hooks (provided by pytest-html plugin)
+#   and added to the HTML report
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "requirements(issues=[issue1, issue2]): link to GitHub issue (traceability)",
+    )
+
+
+def pytest_runtest_setup(item: Item):
+    collected_issue_ids = []  # type: List[str]
+    print("pytest_runtest_setup")
+    print(item)
+    for requirement_marker in item.iter_markers("requirements"):
+        print("MARKER")
+        print(requirement_marker)
+        if requirement_marker and "issues" in requirement_marker.kwargs:
+            collected_issue_ids.extend(requirement_marker.kwargs.get("issues"))
+        print("GOT ISSUES")
+    # Only keep unique IDs and sorted them
+    item.issue_ids = sorted(set(collected_issue_ids))
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item: Item, call):
+    outcome = yield
+
+    report = outcome.get_result()
+
+    if hasattr(item, "issue_ids"):
+        report.issue_ids = item.issue_ids
+
+
+def pytest_html_results_table_header(cells):
+    # remove "links" column
+    cells.pop()
+    cells.insert(
+        0, html.th("Requirement", class_="sortable requirement", col="requirement")
+    )
+
+
+def pytest_html_results_table_row(report, cells):
+    base_url = "https://github.com/SAP/data-attribute-recommendation-python-sdk/issues/"
+
+    # remove "links" column
+    cells.pop()
+    issue_ids = getattr(report, "issue_ids", None)
+
+    if issue_ids:
+        links = []
+        for issue_id in issue_ids:
+            url = base_url + issue_id
+            # There must be a plain-text node inside the `td`, or the table sorting
+            # will break. This is why the `a` element is added separately.
+            links.append(f"SAP/data-attribute-recommendation-python-sdk#{issue_id} ")
+            links.append(html.a("Link", href=url))
+            links.append(html.br())
+        # remove last <br>
+        links.pop()
+        cell = html.td(*links, class_="col-requirement")
+    else:
+        cell = html.td("N/A", class_="col-requirement")
+
+    cells.insert(0, cell)

--- a/system_tests/conftest.py
+++ b/system_tests/conftest.py
@@ -90,7 +90,7 @@ def pytest_runtest_setup(item: Item):
     for requirement_marker in item.iter_markers("requirements"):
         if requirement_marker and "issues" in requirement_marker.kwargs:
             collected_issue_ids.extend(requirement_marker.kwargs.get("issues"))
-    # Only keep unique IDs and sorted them
+    # Only keep unique IDs and sort them
     item.issue_ids = sorted(set(collected_issue_ids))
 
 

--- a/system_tests/conftest.py
+++ b/system_tests/conftest.py
@@ -81,7 +81,7 @@ def model_creator(dar_url, credentials_source):
 def pytest_configure(config):
     config.addinivalue_line(
         "markers",
-        "requirements(issues=[issue1, issue2]): link to GitHub issue (traceability)",
+        "requirements(issues=[issue1, ...]): link to GitHub issue (traceability)",
     )
 
 

--- a/system_tests/workflow/test_end_to_end.py
+++ b/system_tests/workflow/test_end_to_end.py
@@ -13,6 +13,7 @@ from sap.aibus.dar.client.workflow.model import ModelCreator
 logger = logging.getLogger("test")
 
 
+@pytest.mark.requirements(issues=["42"])
 class TestEndToEnd:
     """
     Tests an end-to-end scenario:

--- a/tests/sap/aibus/dar/client/test_inference_client.py
+++ b/tests/sap/aibus/dar/client/test_inference_client.py
@@ -27,6 +27,7 @@ def inference_client():
     return prepare_client(DAR_URL, InferenceClient)
 
 
+@pytest.mark.requirement(issue="42")
 class TestInferenceClient:
     @property
     def objects(self):

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ deps =
     pytest==5.3.5
     pytest-cov==2.8.1
     coveralls==2.0.0
+    system_tests: pytest-html==2.1.1
 
 commands =
     mkdir -p test_results/{envname}/
@@ -39,6 +40,7 @@ commands =
     --log-cli-level INFO \
     --junitxml=system_test_results/unit_xunit.xml \
     --junit-prefix={envname} \
+    --html=system_test_results/traceability.html \
     -o junit_suite_name={envname} \
     -o console_output_style=classic \
     -o junit_family=xunit2 \


### PR DESCRIPTION
This PR implements a traceability report.

The traceability report is always created during the system_tests stage. Only for tagged releases, the report is uploaded as a Github release, abusing this feature to store the document.

The mapping from a test case to a Github issue is achieved using custom pytest markers. The report is created using custom hooks for the pytest-html plugin, which consume the pytest markers and add links for each relevant test case to the requirement.

Upload of the report has not been tested yet. Travis refuses to execute the Deploy stage on a PR build. I will test it live. the current requirements mappings references issue #42, which I will fill in later.

Thanks @The-Compiler for the help here!
