### PR TITLE
Documentation cleanup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,7 @@ repos:
             --disable=import-error,
         ]
         exclude: (tests|docs)
+-   repo: https://github.com/PyCQA/doc8
+    rev: '0.8.1'
+    hooks:
+    -   id: doc8

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -5,7 +5,8 @@ API Documentation
 =================
 
 This document describes the Python API available in the SDK. The RESTful API
-exposed by the Data Attribute Recommendation service itself is described in the `SAP Help Portal`_.
+exposed by the Data Attribute Recommendation service itself is described in the
+`SAP Help Portal`_.
 
 The API exposed by the Python SDK either maps directly to a RESTful API
 of the service or provides a convenient wrapper around the RESTful API.

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -1,0 +1,7 @@
+Development
+===========
+
+.. toctree::
+
+  release_process.rst
+  traceability.rst

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -198,8 +198,8 @@ output (edited for brevity):
     INFO:sap.aibus.dar.client.workflow.model.ModelCreator:Training finished successfully. Job ID: 'bca5f678-c5d7-453c-af37-69505187dc9b'
 
 
-The last lines will be the result of ``pprint.pprint(final_api_response)``. This is the response sent by the RESTful API
-when querying the model status:
+The last lines will be the result of ``pprint.pprint(final_api_response)``.
+This is the response sent by the RESTful API when querying the model status:
 
 .. code-block:: python
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -577,7 +577,7 @@ Table of Contents
     api.rst
     retry.rst
     security.rst
-    release_process.rst
+    development.rst
 
 
 

--- a/docs/source/retry.rst
+++ b/docs/source/retry.rst
@@ -6,24 +6,27 @@ Resilience and Error Recovery
 Retrying HTTP Requests
 **********************
 
-The Data Attribute Recommendation Python SDK will retry failed HTTP operations to some extent.
+The Data Attribute Recommendation Python SDK will retry failed HTTP operations to some
+extent.
 
-Because the Data Attribute Recommendation service uses a RESTful API, the standard HTTP semantics apply.
+Because the Data Attribute Recommendation service uses a RESTful API, the standard
+HTTP semantics apply.
 
 This makes it safe by default to retry requests using the GET or DELETE methods
 since these methods are either safe or idempotent.
 
-GET is what is called a `safe method`_ because repeating a GET request should not have any
-side-effects. Accordingly, identical requests can be performed several times
+GET is what is called a `safe method`_ because repeating a GET request should not have
+any side-effects. Accordingly, identical requests can be performed several times
 without ill effects.
 
 DELETE is not a safe method. It usually has side-effects such as deleting a resource
 from a server.
-However, DELETE is an `idempotent method`_. A request can be repeated several times and the result
-will always be the same: the resource is gone. Note that all safe methods are also
-idempotent!
+However, DELETE is an `idempotent method`_. A request can be repeated several times and
+the result will always be the same: the resource is gone. Note that all safe methods
+are also idempotent!
 
-These properties allow the Data Attribute Recommendation Python SDK to retry many operations by default.
+These properties allow the Data Attribute Recommendation Python SDK to retry many
+operations by default.
 
 .. _safe method: https://tools.ietf.org/html/rfc7231#section-4.2.1
 .. _idempotent method: https://tools.ietf.org/html/rfc7231#section-4.2.2
@@ -35,17 +38,19 @@ Retrying POST Requests
 POST requests are not idempotent. They can not be retried, at least not
 safely according to HTTP semantics.
 
-For the Data Attribute Recommendation Python SDK, this contains all *create_* methods since these are implemented
+For the Data Attribute Recommendation Python SDK, this contains all *create_* methods
+since these are implemented
 using POST. Where possible, the SDK provides a parameter to enable retry
 behavior on the method itself. Before using this manual override to force retries for
 POST, consider the trade-offs involved.
 
 Consider the creation of a DatasetSchema using
-:meth:`DataManagerClient.create_dataset_schema`. In a scenario where
-the connection between client and server is dropped suddenly, the DatasetSchema may
-have been created successfully.
-On the client side, the Data Attribute Recommendation Python SDK receives a "connection reset" error message
-and is unaware that the new DatasetSchema has been created.
+:meth:`~sap.aibus.dar.client.data_manager_client.DataManagerClient.create_dataset_schema`.
+In a scenario where the connection between client and server is dropped suddenly, the
+DatasetSchema may have been created successfully.
+On the client side, the Data Attribute Recommendation Python SDK receives a
+"connection reset" error message and is unaware that the new DatasetSchema has been
+created.
 Implementing a naive retry simply based on HTTP semantics will lead to the creation
 of a second DatasetSchema, because the HTTP client is not aware that the first
 DatasetSchema was created.
@@ -58,7 +63,8 @@ DatasetSchema was created. If the DatasetSchema is not there, a new request can 
 POST Requests which Acquire Limited Resources
 -----------------------------------------------
 
-Note that not all *create_* methods implement a *retry* parameter. The `create_deployment`
+Note that not all *create_* methods implement a *retry* parameter. The
+:meth:`~sap.aibus.dar.client.model_manager_client.ModelManagerClient.create_deployment`
 method can only be called once per model name. No two deployments can exist at the same
 time for any model. For this reason, there is no naive retry implementation based on
 repeating the initial failing request. Such an implementation cannot know if
@@ -67,14 +73,14 @@ successful, the second request will fail with a seemingly unrelated error relate
 the model already being deployed.
 
 See the documentation of the individual *create_* methods for details. For some tasks,
-the Data Attribute Recommendation Python SDK provides higher-level methods which implement application-level retry
-including clean up of any singleton resources.
+the Data Attribute Recommendation Python SDK provides higher-level methods which
+implement application-level retry including clean up of any singleton resources.
 
 Before Connection is Established
 --------------------------------
 
-If an error occurs before the initial connection to the server is established (
-i.e. connect timeout, DNS lookup problem), all HTTP methods are retried.
+If an error occurs before the initial connection to the server is established (i.e.
+connect timeout, DNS lookup problem), all HTTP methods are retried.
 
 At this point, the server has not yet received the request. No unsafe side-effects
 have happened yet, so it is safe to retry all HTTP methods.
@@ -87,7 +93,8 @@ started via `create_` method calls and executed in the background. Their progres
 and success status is exposed not via HTTP status codes in the response sent by
 the API endpoint, but in the JSON body of the response.
 
-For this reason, these operations cannot be retried at all by the HTTP-level retry implementation described above.
+For this reason, these operations cannot be retried at all by the HTTP-level retry
+implementation described above.
 
-The Data Attribute Recommendation Python SDK provides higher-level methods which can handle restarting the
-individual processes, if desired.
+The Data Attribute Recommendation Python SDK provides higher-level methods which can
+handle restarting the individual processes, if desired.

--- a/docs/source/security.rst
+++ b/docs/source/security.rst
@@ -54,8 +54,8 @@ The Data Attribute Recommendation service uses HTTPS for communication.
 
 With an outdated operating system or Python environment, it may be easier
 for a hypothetical man-in-the-middle attacker to find out the service key you are
-using or otherwise intercept or interfere with your communication with the Data Attribute
-Recommendation service.
+using or otherwise intercept or interfere with your communication with the Data
+Attribute Recommendation service.
 
 To avoid this possibility, two properties should hold:
 * The SDK should authenticate the remote side of the connection
@@ -66,9 +66,9 @@ HTTPS communication. Note that the SDK will reject non-HTTPS URLs.
 
 .. _requests: https://requests.readthedocs.io/en/master/
 
-Internally, the ``requests`` library uses the ``certifi`` library as a source of root `CA
-certificates`_. These are used to validate the TLS certificate presented by the remote
-server.
+Internally, the ``requests`` library uses the ``certifi`` library as a source of root
+`CA certificates`_. These are used to validate the TLS certificate presented by the
+remote server.
 The ``certifi`` library can and should be updated independently, as recommended
 by the `requests`_ documentation.
 Additionally, the ``requests`` packages also verifies that the host name inside the

--- a/docs/source/traceability.rst
+++ b/docs/source/traceability.rst
@@ -1,0 +1,121 @@
+.. traceability:
+
+
+Maintaining Traceability Reports
+================================
+
+To fulfill SAP-internal corporate requirements, this project maintains
+**Test Evaluation Reports** for each release.
+
+These reports allow the following:
+
+* Understand what **requirements** were tested
+* Understand **which tests** were used to validate the requirements
+* Understand if those tests were **successful**
+
+Hence, a test evaluation report traces requirements to tests to test execution and
+is thus also called a **Traceability Report**.
+
+The reports are generated during ::`release_process<release builds>`
+on Travis. Once all tests have passed successfully, the report is published
+as an artifact on the `Github release page`_ for the corresponding version
+of the SDK.
+
+If the build on Travis is not successful, no artifact is uploaded to Pypi and also
+no test evaluation report is uploaded.
+
+.. _Github release page: https://github.com/SAP/data-attribute-recommendation-python-sdk/releases
+
+
+Linking Tests to Requirements
+*****************************
+
+When implementing a new **functional** requirement,
+**you must also add a test** to show that it is working. Inside this test, use
+the pytest framework to set a special marker which references the Github issue
+describing the requirement.
+
+With this marker in place, we know which requirements are tested by which test. The
+result of the test execution is collected implicitly by pytest during test execution.
+
+To link a test to requirement `#42`_ on Github, you can use the following
+syntax:
+
+.. note::
+
+    Requirements are maintained as GitHub issues.
+
+.. _#42: https://github.com/SAP/data-attribute-recommendation-python-sdk/issues/42
+
+.. code-block:: python
+
+    import pytest
+
+    @pytest.mark.requirements(issues=["42"])
+    def test_new_feature():
+      # implement test
+      assert False
+
+It is also possible to reference multiple issues:
+
+.. code-block:: python
+
+    import pytest
+
+    @pytest.mark.requirements(issues=["42", "43", "44"])
+    def test_new_feature_2():
+      # implement test
+      assert False
+
+The marker can also be applied on a class encapsulating several tests. Additionally,
+individual tests inside the class may also be linked to other requirements:
+
+.. code-block:: python
+
+  import pytest
+
+  @pytest.mark.requirements(issues=["42", "43"])
+  class TestNewFeature:
+
+    def test_feature_1(self):
+      # implement test
+      assert False
+
+
+    @pytest.mark.requirements(issues=["44"])
+    def test_feature_2(self):
+      # implement test
+      assert False
+
+    @pytest.mark.requirements(issues=["45"])
+    def test_feature_3():
+      # implement test
+      assert False
+
+The resulting Test Evaluation report would link issues and tests as follows:
+
+Simple table:
+
+===========  =================================
+Issues       Tests
+===========  =================================
+42, 43       ``TestNewFeature.test_feature_1``
+42, 43, 44   ``TestNewFeature.test_feature_2``
+42, 43, 45   ``TestNewFeature.test_feature_3``
+===========  =================================
+
+The test evaluation report is only generated when using pytest's html output. This
+requires the ``pytest-html`` plugin and use the ``--html`` option when calling pytest.
+On Travis, this is handled via `tox`_.
+
+.. _tox: https://github.com/SAP/data-attribute-recommendation-python-sdk/blob/master/tox.ini
+
+.. note::
+
+  Currently, only system tests can be linked to requirements. While it may be useful
+  to link unit or integration tests to functional requirements, this is currently
+  simply not implemented. Both the required pytest instrumentation, the report
+  generation and the report uploaded are only implemented for system tests. See
+  pull request `#48`_ for the implementation details.
+
+.. _#48: https://github.com/SAP/data-attribute-recommendation-python-sdk/pull/48

--- a/tox.ini
+++ b/tox.ini
@@ -45,3 +45,7 @@ commands =
     -o console_output_style=classic \
     -o junit_family=xunit2 \
     system_tests
+
+[doc8]
+# align line length with black
+max-line-length=88


### PR DESCRIPTION
Includes #49 

* Add doc8 to pre-commit checks (will also run on Travis)
* Reformat documentation to make doc8 clean
* Fix some links in documentation
