### PR TITLE
Log with INFO level while waiting for job to succeed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Documentation: add link to SAP community [#58]
 * `ModelCreator.create` performs an initial check if the model name is already used
   and raises `ModelAlreadyExists` in this case [#60], [#64]
+* `ModelManager.wait_for_job` now logs with level INFO while polling [#66]
 
 ### Fixed
 
@@ -26,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#60]: https://github.com/SAP/data-attribute-recommendation-python-sdk/issues/60
 [#63]: https://github.com/SAP/data-attribute-recommendation-python-sdk/pull/63
 [#64]: https://github.com/SAP/data-attribute-recommendation-python-sdk/pull/64
+[#66]: https://github.com/SAP/data-attribute-recommendation-python-sdk/pull/66
 
 ## [0.6.8]
 

--- a/sap/aibus/dar/client/model_manager_client.py
+++ b/sap/aibus/dar/client/model_manager_client.py
@@ -210,7 +210,7 @@ class ModelManagerClient(BaseClientWithSession):
         )
 
         def polling_function():
-            self.log.debug("Polling for status of job '%s'", job_id)
+            self.log.info("Polling for status of job '%s'", job_id)
             return self.read_job_by_id(job_id)
 
         self.log.info("Waiting for job '%s' to finish.", job_id)


### PR DESCRIPTION
A job can take a while to finish and it is nice to see some
output in the meantime. This change aligns the log level for
the polling message with the Dataset polling in DataManager.

Fixes #34.