### PR TITLE
Log job progress in ModelManagerClient.wait_for_job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Log job progress in ModelManagerClient.wait_for_job [#87]
 
-[#87] : https://github.com/SAP/data-attribute-recommendation-python-sdk/pull/81
+[#87] : https://github.com/SAP/data-attribute-recommendation-python-sdk/pull/87
 
 ## [0.7.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#81] : https://github.com/SAP/data-attribute-recommendation-python-sdk/pull/81
 
+* Log job progress in ModelManagerClient.wait_for_job [#87]
+
+[#87] : https://github.com/SAP/data-attribute-recommendation-python-sdk/pull/81
+
 ## [0.7.0]
 
 ### Added

--- a/sap/aibus/dar/client/model_manager_client.py
+++ b/sap/aibus/dar/client/model_manager_client.py
@@ -211,7 +211,14 @@ class ModelManagerClient(BaseClientWithSession):
 
         def polling_function():
             self.log.info("Polling for status of job '%s'", job_id)
-            return self.read_job_by_id(job_id)
+            job_resource = self.read_job_by_id(job_id)
+            self.log.info(
+                "Job '%s': status '%s', progress: '%s'",
+                job_id,
+                job_resource["status"],
+                job_resource["progress"],
+            )
+            return job_resource
 
         self.log.info("Waiting for job '%s' to finish.", job_id)
 


### PR DESCRIPTION
This makes it easier to see current progress in interactive sessions.