### PR TITLE
Construct Client from CloudFoundry service binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add [CONTRIBUTING.md] and [SECURITY.md] [#92]
 * This project is now following the [Best Practices] set forth by the
   Core Infrastructure Initiative! See [CII badge details]. [#92]
+* Add `construct_from_cf_env` method to construct client instances from
+  Data Attribute Recommendation service binding on SAP Business Technology
+  Platform. [#97]
 
 [CONTRIBUTING.md]: /CONTRIBUTING.md
 [SECURITY.md]: /SECURITY.md
@@ -18,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [CII badge details]: https://bestpractices.coreinfrastructure.org/en/projects/4514
 
 [#92]: https://github.com/SAP/data-attribute-recommendation-python-sdk/pull/92
+[#97]: https://github.com/SAP/data-attribute-recommendation-python-sdk/pull/92
 
 ### Changed
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-requests==2.23.0
-typing-extensions==3.7.4.1
+cfenv==0.5.3
+requests==2.25.1
+typing-extensions==3.10.0.0

--- a/sap/aibus/dar/client/base_client.py
+++ b/sap/aibus/dar/client/base_client.py
@@ -3,6 +3,8 @@ Shared infrastructure for microservice clients.
 """
 from typing import TypeVar, Type
 
+from cfenv import AppEnv
+
 from sap.aibus.dar.client.util.credentials import (
     CredentialsSource,
     OnlineCredentialsSource,
@@ -86,6 +88,23 @@ class BaseClient(LoggerMixin):
         """
         source = StaticCredentialsSource(token)
         return cls(dar_url, source)
+
+    @classmethod
+    def construct_from_cf_env(cls: Type[DARClient]) -> DARClient:
+        """
+        Constructs a DARClient from service binding in a CloudFoundry app.
+
+        This is useful when the SDK is used in a CloudFoundry application on the
+        SAP Business Technology Platform where the application is bound to an instance
+        of the Data Attribute Recommendation service.
+
+        This constructor assumes that only one instance of the service is bound
+        to the app.
+        :return: the client instance
+        """
+        env = AppEnv()
+        dar = env.get_service(label="data-attribute-recommendation")
+        return cls.construct_from_service_key(dar.credentials)
 
 
 class BaseClientWithSession(BaseClient):

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     author="Michael Haas",
     author_email="michael.haas01@sap.com",
     url="https://github.com/sap/data-attribute-recommendation-python-sdk",
-    install_requires=["requests>=2.20.0", "typing-extensions>=3.7.4.1"],
+    install_requires=["requests~=2.20.0", "typing-extensions~=3.7.4.1", "cfenv~=0.5.3"],
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
     python_requires="~=3.5",


### PR DESCRIPTION
With this change, the client can be constructed directly from a service binding (in `VCAP_SERVICES`) to the Data Attribute Recommendation service on the SAP Business Technology Platform.