### PR TITLE
Add support for custom Job and Deployment IDs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,30 +2,38 @@ default_language_version:
     python: python3.7
 repos:
 -   repo: https://github.com/ambv/black
-    rev: 19.3b0
+    rev: 21.6b0
     hooks:
     - id: black
       language_version: python3.7
       args: ['--target-version', 'py35']
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.2.3
+-   repo: https://github.com/pycqa/flake8
+    rev: 3.9.2
     hooks:
     - id: flake8
-      additional_dependencies: ["flake8-bugbear==19.3.0"]
+      additional_dependencies: [ "flake8-bugbear==21.4.3" ]
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
     - id: name-tests-test
       args: ['--django']
 -   repo: https://github.com/PyCQA/bandit
-    rev: '1.6.1'
+    rev: '1.7.0'
     hooks:
     - id: bandit
       exclude: tests/
+      args:
+        - '-s'
+        - 'B101' # allow use of assert
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.761'
+    rev: 'v0.902'
     hooks:
     - id: mypy
       exclude: docs/
+      additional_dependencies:
+        - "types-requests~=0.1.9" # type stubs for requests. mypy 0.900 no longer ships these.
 -   repo: https://github.com/pre-commit/mirrors-pylint
-    rev: 'v2.4.3'
+    rev: 'v2.7.4'
     hooks:
     -   id: pylint
         args: [

--- a/.travis.yml
+++ b/.travis.yml
@@ -112,6 +112,10 @@ jobs:
     python: "3.8"
     env: TOXENV=py38-cov
   - stage: test
+    name: "Python: 3.9 on Linux"
+    python: "3.9"
+    env: TOXENV=py39-cov
+  - stage: test
     name: "Python: pypy3 on Linux"
     python: "pypy3"
     env: TOXENV=pypy3-cov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.8.0]
 
-
 ### Added
 
 * Add [CONTRIBUTING.md] and [SECURITY.md] [#92]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add `construct_from_cf_env` method to construct client instances from
   Data Attribute Recommendation service binding on SAP Business Technology
   Platform. [#97]
+* Add support for user-specified Job and Deployment IDs when creating the
+  respective Job and Deployment resources. This change is not yet generally
+  available in the Data Attribute Recommendation service. [#98]
 
 [CONTRIBUTING.md]: /CONTRIBUTING.md
 [SECURITY.md]: /SECURITY.md
@@ -25,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#92]: https://github.com/SAP/data-attribute-recommendation-python-sdk/pull/92
 [#97]: https://github.com/SAP/data-attribute-recommendation-python-sdk/pull/97
+[#98]: https://github.com/SAP/data-attribute-recommendation-python-sdk/pull/98
+
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#97]: https://github.com/SAP/data-attribute-recommendation-python-sdk/pull/97
 [#98]: https://github.com/SAP/data-attribute-recommendation-python-sdk/pull/98
 
+### Deprecated
+
+* Python 3.5 has reached [end-of-life in September 2020](https://www.python.org/downloads/release/python-3510/).
+  Support for Python 3.5 will be removed in one of the upcoming releases.
+
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0]
+
+
 ### Added
 
 * Add [CONTRIBUTING.md] and [SECURITY.md] [#92]
@@ -21,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [CII badge details]: https://bestpractices.coreinfrastructure.org/en/projects/4514
 
 [#92]: https://github.com/SAP/data-attribute-recommendation-python-sdk/pull/92
-[#97]: https://github.com/SAP/data-attribute-recommendation-python-sdk/pull/92
+[#97]: https://github.com/SAP/data-attribute-recommendation-python-sdk/pull/97
 
 ### Changed
 
@@ -154,7 +157,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * First public release
 
-[Unreleased]: https://github.com/SAP/data-attribute-recommendation-python-sdk/compare/rel/0.7.1...HEAD
+[Unreleased]: https://github.com/SAP/data-attribute-recommendation-python-sdk/compare/rel/0.8.0...HEAD
+[0.8.0]: https://github.com/SAP/data-attribute-recommendation-python-sdk/compare/rel/0.7.1...rel/0.8.0
 [0.7.1]: https://github.com/SAP/data-attribute-recommendation-python-sdk/compare/rel/0.7.0...rel/0.7.1
 [0.7.0]: https://github.com/SAP/data-attribute-recommendation-python-sdk/compare/rel/0.6.8...rel/0.7.0
 [0.6.8]: https://github.com/SAP/data-attribute-recommendation-python-sdk/compare/rel/0.6.7...rel/0.6.8

--- a/README.md
+++ b/README.md
@@ -42,11 +42,14 @@ pay attention to the [CHANGELOG.md].
 # Requirements
 
 To use the SDK, you will need a recent version of Python. We actively support
-and test Python 3.5 up to Python 3.8. We aim to support all officially supported
+and test Python ~~3.5~~ 3.6 up to Python 3.8. We aim to support all officially supported
 Python version. This includes any Python version not
 listed as `end-of-life` in the
 [Python Developer's Guide](https://devguide.python.org/#branchstatus). You can check
 the [Travis builds] to see which environments are actively tested.
+
+**NOTE:** Python 3.5 is [end-of-life since September 2021](https://www.python.org/downloads/release/python-3510/).
+The SDK will **remove support** for Python 3.5 at some point after the 0.8.0 release.
 
 Additionally, the `pip` and `virtualenv` tools should be installed. See
 the [installation instructions][pip and virtual environments].

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,7 +9,7 @@ Features
 - Easy to use
 - High-level flows on top of the basic Data Attribute Recommendation APIs
 - Fully type annotated for great autocomplete experience
-- Supports Python 3.5 up to 3.8
+- Supports Python 3.6 up to 3.8 (3.5 will be removed in an upcoming release)
 
 Release Notes
 -------------

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
 # see docs/requirements.txt
-pre-commit==2.2.0
+pre-commit==2.13.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,4 +3,4 @@
 # whitesource.
 # These dependencies are never shipped, but only used locally
 # on a developer's workstation or on Jenkins for development.
-tox==3.14.5
+tox==3.23.1

--- a/sap/aibus/dar/client/exceptions.py
+++ b/sap/aibus/dar/client/exceptions.py
@@ -32,7 +32,7 @@ class HTTPSRequired(DARException):
 
     def __init__(self):
         msg = "URL must use https scheme. Unencrypted connections are not supported."
-        super(HTTPSRequired, self).__init__(msg)
+        super().__init__(msg)
 
 
 class DARPollingTimeoutException(DARException):
@@ -129,7 +129,7 @@ class ModelAlreadyExists(DARException):
             "To re-use the name, please delete the model"
             " first or choose a different name."
         )
-        super(ModelAlreadyExists, self).__init__(msg)
+        super().__init__(msg)
 
 
 class DARHTTPException(DARException):
@@ -146,7 +146,7 @@ class DARHTTPException(DARException):
     """
 
     def __init__(self, url: str, response: Response):
-        super(DARHTTPException, self).__init__()
+        super().__init__()
         self.url = url
         self._response = response
         self.exception_timestamp = datetime.datetime.now(tz=datetime.timezone.utc)

--- a/sap/aibus/dar/client/util/http_transport.py
+++ b/sap/aibus/dar/client/util/http_transport.py
@@ -175,7 +175,7 @@ class RetrySession(HttpMethodsMixin):  # pylint: disable=too-few-public-methods
         :param status_forcelist: a set of integer HTTP response codes that will lead
             to retry.
         """
-        super(RetrySession, self).__init__()
+        super().__init__()
         session = session or Session()
         retry = Retry(
             total=num_retries,
@@ -252,7 +252,7 @@ class TimeoutSession(HttpMethodsMixin):
         :param connect_timeout: timeout for the connection
         :param read_timeout: maximum time between bytes after connect
         """
-        super(TimeoutSession, self).__init__()
+        super().__init__()
         self.session = session or Session()
 
         self.connect_timeout = connect_timeout
@@ -301,7 +301,7 @@ class TimeoutRetrySession(HttpMethodsMixin):
             connect_timeout: connect timeout
             read_timeout: read timeout
         """
-        super(TimeoutRetrySession, self).__init__()
+        super().__init__()
         retry_session = self._make_retry_session(num_retries)
         timeout_session = TimeoutSession(
             session=retry_session,

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Environment :: Console",

--- a/tests/sap/aibus/dar/client/test_model_manager_client.py
+++ b/tests/sap/aibus/dar/client/test_model_manager_client.py
@@ -148,6 +148,34 @@ class TestModelManagerClientModelJob:
             == response
         )
 
+    def test_create_job_with_external_job_id(self, model_manager_client):
+        model_template_id = "d7810207-ca31-4d4d-9b5a-841a644fd81f"
+        dataset_id = "a2058037-2ae4-465e-8110-65381d47f3d4"
+        model_name = "my_test_model"
+        job_id = "24b38880-e304-4d0e-87cf-b9feb8b21393"
+
+        model_manager_client.create_job(
+            model_template_id=model_template_id,
+            dataset_id=dataset_id,
+            model_name=model_name,
+            job_id=job_id,
+        )
+
+        expected_url = "/model-manager/api/v3/jobs"
+        expected_payload = {
+            "datasetId": dataset_id,
+            "modelTemplateId": model_template_id,
+            "modelName": model_name,
+            "id": job_id,
+        }
+
+        expected_post_call = [call(expected_url, payload=expected_payload)]
+
+        assert (
+            expected_post_call
+            == model_manager_client.session.post_to_endpoint.call_args_list
+        )
+
     def test_wait_for_job_uses_polling(self, model_manager_client: ModelManagerClient):
         """
         Tests the interaction of the `wait_for_job` method with the Polling class.
@@ -239,7 +267,7 @@ class TestModelManagerClientModelJob:
 
         assert str(exc_info.value) == expected_message
 
-    def test_start_job_and_wait(self, model_manager_client: ModelManagerClient):
+    def test_create_job_and_wait(self, model_manager_client: ModelManagerClient):
         """
         Tests if start_job_and_wait correctly orchestrates start_job()
         and wait_for_job().
@@ -271,6 +299,57 @@ class TestModelManagerClientModelJob:
             model_template_id=model_template_id,
             dataset_id=dataset_id,
             model_name=model_name,
+            job_id=None,
+        )
+
+        assert model_manager_client.create_job.call_args_list == [
+            expected_create_job_call_args
+        ]
+
+        expected_wait_for_job_call_args = call(job_resource["id"])
+
+        assert model_manager_client.wait_for_job.call_args_list == [
+            expected_wait_for_job_call_args
+        ]
+
+    def test_create_job_and_wait_with_external_job_id(
+        self, model_manager_client: ModelManagerClient
+    ):
+        """
+        Tests if start_job_and_wait correctly orchestrates start_job()
+        and wait_for_job() if an external Job ID is used.
+        """
+        model_template_id = "d7810207-ca31-4d4d-9b5a-841a644fd81f"
+        dataset_id = "a2058037-2ae4-465e-8110-65381d47f3d4"
+        model_name = "my_test_model"
+        job_id = "6f122888-3ab9-4485-9b10-d1b982239ab9"
+
+        job_resource = self._make_job_resource("SUCCEEDED")
+        job_resource["id"] = job_id
+
+        model_manager_client.create_job = create_autospec(
+            model_manager_client.create_job
+        )
+        model_manager_client.create_job.return_value = job_resource
+
+        model_manager_client.wait_for_job = create_autospec(
+            model_manager_client.wait_for_job
+        )
+
+        ret_val = model_manager_client.create_job_and_wait(
+            model_name=model_name,
+            dataset_id=dataset_id,
+            model_template_id=model_template_id,
+            job_id=job_id,
+        )
+
+        assert ret_val == model_manager_client.wait_for_job.return_value
+
+        expected_create_job_call_args = call(
+            model_template_id=model_template_id,
+            dataset_id=dataset_id,
+            model_name=model_name,
+            job_id=job_id,
         )
 
         assert model_manager_client.create_job.call_args_list == [
@@ -466,6 +545,25 @@ class TestModelManagerClientDeployment:
             == response
         )
 
+    def test_create_deployment_with_external_id(
+        self, model_manager_client: ModelManagerClient
+    ):
+        model_name = "my_test_model"
+        deployment_id = "abcd-deployment-id"
+
+        model_manager_client.create_deployment(
+            model_name=model_name, deployment_id=deployment_id
+        )
+
+        expected_url = "/model-manager/api/v3/deployments"
+        expected_payload = {"modelName": model_name, "id": deployment_id}
+        expected_post_call = [call(expected_url, payload=expected_payload)]
+
+        assert (
+            expected_post_call
+            == model_manager_client.session.post_to_endpoint.call_args_list
+        )
+
     def _make_deployment_resource(self, status):
         return make_deployment_resource(status)
 
@@ -621,7 +719,55 @@ class TestModelManagerClientDeployment:
         # assert
         assert return_value == model_manager_client.wait_for_deployment.return_value
 
-        expected_call_to_create_deployment = call(model_name=model_name)
+        expected_call_to_create_deployment = call(
+            model_name=model_name, deployment_id=None
+        )
+
+        assert model_manager_client.create_deployment.call_args_list == [
+            expected_call_to_create_deployment
+        ]
+
+        expected_call_to_wait_for_deployment = call(
+            deployment_id=deployment_resource["id"]
+        )
+
+        assert model_manager_client.wait_for_deployment.call_args_list == [
+            expected_call_to_wait_for_deployment
+        ]
+
+    def test_deploy_and_wait_with_external_deployment_id(
+        self, model_manager_client: ModelManagerClient
+    ):
+        """
+        Tests if *deploy_and_wait* orchestrates *create_deployment* and
+        *wait_for_deployment* correctly if an external deployment ID is given.
+        """
+
+        deployment_id = "abcd"
+        model_name = "my-test-model"
+
+        # prepare
+        deployment_resource = self._make_deployment_resource("PENDING")
+        deployment_resource["id"] = deployment_id
+        model_manager_client.create_deployment = create_autospec(
+            model_manager_client.create_deployment, return_value=deployment_resource
+        )
+
+        model_manager_client.wait_for_deployment = create_autospec(
+            model_manager_client.wait_for_deployment
+        )
+
+        # act
+        return_value = model_manager_client.deploy_and_wait(
+            model_name=model_name, deployment_id=deployment_id
+        )
+
+        # assert
+        assert return_value == model_manager_client.wait_for_deployment.return_value
+
+        expected_call_to_create_deployment = call(
+            model_name=model_name, deployment_id=deployment_id
+        )
 
         assert model_manager_client.create_deployment.call_args_list == [
             expected_call_to_create_deployment

--- a/tests/sap/aibus/dar/util/test_http_transport.py
+++ b/tests/sap/aibus/dar/util/test_http_transport.py
@@ -45,7 +45,7 @@ class _BaseRetrySessionTest(_BaseHTTPSEnforcedTest):
             expected_schemes.remove(scheme)
 
             self._assert_retry_set_up_correctly(adapter)
-        len(expected_schemes) == 0
+        assert len(expected_schemes) == 0
 
     def test_can_override_session(self):
         mock_session = create_autospec(Session, instance=True)
@@ -54,7 +54,7 @@ class _BaseRetrySessionTest(_BaseHTTPSEnforcedTest):
 
         assert mock_session.mount.call_count == 2
 
-        session.session == mock_session
+        assert session.session == mock_session
 
         for cal in mock_session.mount.call_args_list:
             adapter = cal[0][1]

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ passenv = DAR_* TRAVIS TRAVIS_* COVERALLS_*
 
 deps =
     zipp<2.0.0 # for python 3.5 support
-    pytest==6.2.4
+    pytest==6.1.2 # latest supporting Python 3.5
     pytest-cov==2.12.1
     cov: coveralls==3.1.0
     system_tests: pytest-html==3.1.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # exclude "system_tests" by default: these need service credentials
-envlist = py35, py36, py37, py38
+envlist = py35, py36, py37, py38, py39
 
 [testenv]
 whitelist_externals = mkdir
@@ -11,17 +11,17 @@ passenv = DAR_* TRAVIS TRAVIS_* COVERALLS_*
 
 deps =
     zipp<2.0.0 # for python 3.5 support
-    pytest==5.3.5
-    pytest-cov==2.8.1
-    cov: coveralls==2.0.0
-    system_tests: pytest-html==2.1.1
+    pytest==6.2.4
+    pytest-cov==2.12.1
+    cov: coveralls==3.1.0
+    system_tests: pytest-html==3.1.1
 
 commands =
     mkdir -p test_results/{envname}/
     pytest \
     --doctest-modules \
     --cov=sap \
-    --cov-fail-under=96 \
+    --cov-fail-under=98 \
     --cov-report= \
     --cov-branch \
     --junitxml=test_results/{envname}/unit_xunit.xml \


### PR DESCRIPTION
This commit adds support for custom Job and Deployment IDs to be
passed to the Data Attribute Recommendation service when creating
the respective Job or Deployments.

This change is not generally available in the service, but the SDK
supports it already.

Additionally, this PR updates all dependencies and checks to latest
along with any fixes required by these updates.