### PR TITLE
 ICNMLSALESSERVICESWDF2-4541-update-readthedocs.yml-conf-path

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,4 +12,5 @@ python:
     - path: .
 
 sphinx:
+    configuration: docs/source/conf.py
     fail_on_warning: true


### PR DESCRIPTION
 As a part of the DAR-SDK documentation updation related to [CNMLSALESSERVICESWDF2-4541](https://jira.tools.sap/browse/ICNMLSALESSERVICESWDF2-4541) the`readthedocs` build failed with the error `Config file validation error Config validation error in build.os. Value build not found`. Hence as a fix updating the config file path in the` .readthedocs.yml` file.



**Checks**:

- [ ] README.md is maintained
- [ ] [Documentation](/docs) is maintained
- [ ] CHANGELOG.md is updated
- [ ] Tests added
