### PR TITLE
ICNMLSALESSERVICESWDF2-4541-fixing-the-format-of-readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,8 +1,10 @@
 # Required
 version: 2
 
-python:
-  version: 3.10
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
   # Install both sphinx AND the package itself; the package
   # is required to install package dependencies. The autodoc package
   # will import the code, which fails if the dependencies are not installed.


### PR DESCRIPTION
As a part of the DAR-SDK documentation updation related to [CNMLSALESSERVICESWDF2-4541](https://jira.tools.sap/browse/ICNMLSALESSERVICESWDF2-4541) `thereadthedocs` build failed with the error `Config file validation error Config validation error in build.os. Value build not found.` Hence as a fix renaming the  the config file to `.readthedocs.yaml` and the format is updated following   [https://docs.readthedocs.com/platform/stable/config-file/v2.html#:~:text=MkDocs-,.readthedocs.yaml,-%EF%83%81](https://docs.readthedocs.com/platform/stable/config-file/v2.html#:~:text=MkDocs-,.readthedocs.yaml,-%EF%83%81)

**Checks**:

- [ ] README.md is maintained
- [ ] [Documentation](/docs) is maintained
- [ ] CHANGELOG.md is updated
- [ ] Tests added
